### PR TITLE
adding a few more Fibonacci algorithms

### DIFF
--- a/EKAlgorithms/EKAlgorithms/NSNumber+EKStuff.h
+++ b/EKAlgorithms/EKAlgorithms/NSNumber+EKStuff.h
@@ -15,6 +15,10 @@
 - (NSUInteger)leastCommonMultipleWithNumber:(NSUInteger)secondNumber;
 - (NSUInteger)factorial;
 + (NSMutableArray *)fibonacciNumbersUpToNumber:(NSUInteger)number;
++ (NSNumber *)fibonacciAtIndex:(NSUInteger)index;
++ (long long int)recursiveFibonacci:(NSUInteger)index;
++ (unsigned long long)fibonacciWithLongLong:(int)index;
++ (NSDecimalNumber *)fibonacciWithDecimal:(int)index;
 - (NSUInteger)sumOfDigits;
 + (NSUInteger)decimalNumberFromBinary:(NSUInteger)binary;
 + (NSUInteger)binaryNumberFromDecimal:(NSUInteger)decimal;

--- a/EKAlgorithms/EKAlgorithms/NSNumber+EKStuff.m
+++ b/EKAlgorithms/EKAlgorithms/NSNumber+EKStuff.m
@@ -74,6 +74,9 @@
 
 #pragma mark - Fibonacci
 
+/*
+ Original implementation does only get Fibonaccis up to the 92nd.
+ */
 + (NSMutableArray *)fibonacciNumbersUpToNumber:(NSUInteger)number
 {
 	NSMutableArray *resultArray = [@[] mutableCopy];
@@ -87,6 +90,74 @@
 	}
     
 	return resultArray;
+}
+
+/*
+ Very slow recursive Fibonacci alogrith.
+ */
++ (long long int)recursiveFibonacci:(NSUInteger)index
+{
+    if (index == 0) {
+        return (long long int)0;
+    } else if (index == 1) {
+        return (long long int)1;
+    } else {
+        return [NSNumber recursiveFibonacci:index - 2] + [NSNumber recursiveFibonacci:index - 1];
+    }
+    
+    
+}
+
+/*
+ Very fast Fibonacci alogrithm. Uses unsigned long long to store numbers up to 
+ 2^64 = 1.8446744e+19 = 18446744073709551615. => 92 is the last index that should
+ work with unsigned long long.
+ */
++ (unsigned long long)fibonacciWithLongLong:(int)index {
+    // this does not work because "last" can't hold a number larger than ULLONG_MAX...
+    if (index > 93) {
+        NSLog(@"Fibonacci at index %i would be too long for ULLONG", index);
+    }
+    
+    unsigned long long beforeLast = 0, last = 1;
+    while (index > 0) {
+        last += beforeLast;
+        beforeLast = last - beforeLast;
+        --index;
+    }
+    
+    if (index == 0) {
+        return beforeLast;
+    }
+    
+    return last;
+}
+
+/*
+ This one uses NSDecimalNumber and is correct until index 185.
+ */
++ (NSDecimalNumber *)fibonacciWithDecimal:(int)index {
+    NSDecimalNumber *beforeLast, *last;
+    beforeLast = [NSDecimalNumber decimalNumberWithMantissa:0 exponent:0 isNegative:NO];
+    last = [NSDecimalNumber decimalNumberWithMantissa:1 exponent:0 isNegative:NO];
+
+    while (index > 0) {
+        last = [last decimalNumberByAdding:beforeLast];
+        beforeLast = [last decimalNumberBySubtracting:beforeLast];
+        --index;
+    }
+    
+    if (index == 0) {
+        return beforeLast;
+    }
+    
+    return last;
+}
+
++ (NSNumber *)fibonacciAtIndex:(NSUInteger)index
+{
+    NSArray *array = [NSNumber fibonacciNumbersUpToNumber:index + 1];
+    return [array objectAtIndex:index];
 }
 
 #pragma mark - Sum of digits of a number

--- a/EKAlgorithms/EKAlgorithms/main.m
+++ b/EKAlgorithms/EKAlgorithms/main.m
@@ -260,6 +260,10 @@ int main(int argc, const char *argv[])
 		NSLog(@"Nodes in list after remove - %lu", (unsigned long)[list count]);
 		[list printList];
         
-	}
+        for (int i = 0; i < 300; i++) {
+            NSLog(@"Fibonacci at index %i: %@", i, [NSNumber fibonacciAtIndex:i]);
+            NSLog(@"Fibonacci at index %i: %@", i, [NSNumber fibonacciWithDecimal:i]);
+        }
+    }
 	return 0;
 }


### PR DESCRIPTION
+fibonacciWithDecimal: uses NSDecimalNumber and can get up to the 186th
number

I'm new to GitHub and I don't know if I'm doing this right… So bare with me, if I screw this up. ;-)

I looked at your Fibonacci algorithm and noticed, that it does only get the numbers right up to the 92nd Fibonacci. This is because, I guess, NSNumber internally uses unsigned long long. Using NSDecimalNumber we're able to get up to 186 correct Fibonaccis. I implemented this one in +fibonacciWithDecimal.

Feel free to include this into your repo, if you think this is worth it.

Thanks for sharing your algorithms! Amazing! :-)
