### PR TITLE
Better count of occurrences of each element in array (#40, #41).

### DIFF
--- a/EKAlgorithms/NSArray+EKStuff.h
+++ b/EKAlgorithms/NSArray+EKStuff.h
@@ -63,6 +63,7 @@
 - (NSNumber *)sumOfElements;
 
 - (NSDictionary *)occurencesOfEachElementInArray;
+- (NSDictionary *)occurencesOfEachElementInArrayByUsingDictionary;
 - (NSDictionary *)CocoaImplementationOfOccurencesOfEachElementInArray;
 
 //search

--- a/EKAlgorithms/NSArray+EKStuff.m
+++ b/EKAlgorithms/NSArray+EKStuff.m
@@ -258,7 +258,7 @@
 		NSUInteger counter = 0;
 		for (NSUInteger j = 0; j < [self count]; j++) {
 			NSParameterAssert(self[j] != nil);
-			if (self[i] == self[j]) {
+			if ([self[i] isEqual:self[j]]) {
 				counter++;
 			}
 		}
@@ -266,6 +266,27 @@
 		           forKey:self[i]];
 	}
     
+	return result;
+}
+
+- (NSDictionary *)occurencesOfEachElementInArrayByUsingDictionary
+{
+	NSMutableDictionary *result = [@{} mutableCopy];
+
+	for (NSUInteger i = 0; i < [self count]; i++) {
+        id currentElement = self[i];
+
+        NSParameterAssert(currentElement != nil);
+
+        NSNumber *existingElementCounter = result[currentElement];
+
+		NSUInteger currentCount = existingElementCounter ? existingElementCounter.unsignedIntegerValue : 0;
+
+        currentCount++;
+
+        result[currentElement] = [NSNumber numberWithUnsignedInteger:currentCount];
+	}
+
 	return result;
 }
 

--- a/EKAlgorithmsApp/EKAlgorithmsApp.xcodeproj/project.pbxproj
+++ b/EKAlgorithmsApp/EKAlgorithmsApp.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		860B787A1858133A0071079A /* NSString+EKStuff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+EKStuff.m"; sourceTree = "<group>"; };
 		860B7888185814810071079A /* NSArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSArray.m; path = ../../EKAlgorithmsSpecs/NSArray.m; sourceTree = "<group>"; };
 		869FE65E186419E600509FE7 /* NSNumber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSNumber.m; path = ../../EKAlgorithmsSpecs/NSNumber.m; sourceTree = "<group>"; };
+		86A2D2D7188AABB3004A908F /* SpecHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecHelpers.h; sourceTree = "<group>"; };
 		F1911596D6814341BCF9FC8E /* libPods-EKAlgorithmsSpecs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EKAlgorithmsSpecs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -179,6 +180,7 @@
 				860B7851185811420071079A /* Supporting Files */,
 				860B7888185814810071079A /* NSArray.m */,
 				869FE65E186419E600509FE7 /* NSNumber.m */,
+				86A2D2D7188AABB3004A908F /* SpecHelpers.h */,
 			);
 			path = EKAlgorithmsSpecs;
 			sourceTree = "<group>";

--- a/EKAlgorithmsApp/EKAlgorithmsExamples/main.m
+++ b/EKAlgorithmsApp/EKAlgorithmsExamples/main.m
@@ -139,9 +139,8 @@ int main(int argc, const char *argv[])
 
         //Find occurences of each element in array
         NSLog(@"Occurences is --> %@", [@[@3, @3, @4, @5, @4, @1, @3, @8, @1] occurencesOfEachElementInArray]);
+        NSLog(@"Occurences by using dictionary is --> %@", [@[@[], @{}, @"four", @"five", @"four", @"one", @"three", @"eight", @"one", @"four"] occurencesOfEachElementInArrayByUsingDictionary]);
         NSLog(@"Occurences via Cocoa APIs is --> %@", [@[@3, @3, @4, @5, @4, @1, @3, @8, @1] CocoaImplementationOfOccurencesOfEachElementInArray]);
-        
-        
         
         //Sieve of Eratosf
 		NSLog(@"Primes from sieve %@", [[NSNumber primeNumbersFromSieveEratosthenesWithMaxNumber:42] description]);

--- a/EKAlgorithmsApp/EKAlgorithmsSpecs/SpecHelpers.h
+++ b/EKAlgorithmsApp/EKAlgorithmsSpecs/SpecHelpers.h
@@ -1,0 +1,7 @@
+
+FOUNDATION_EXPORT uint64_t dispatch_benchmark(size_t count, void (^block)(void));
+static inline void benchmark(size_t n, void(^block)(void)) {
+    float time = (float)dispatch_benchmark(n, block);
+
+    NSLog(@"The block have been run %zu times. It took %f milliseconds",  n, (time / 1000000));
+}

--- a/EKAlgorithmsSpecs/NSArray.m
+++ b/EKAlgorithmsSpecs/NSArray.m
@@ -86,6 +86,50 @@ describe(@"NSArray-based algorithms", ^{
         });
     });
 
+    describe(@"Occurrences of each element in array", ^{
+        describe(@"occurencesOfEachElementInArray", ^{
+            specify(^{
+                NSMutableArray *originalArray = [NSMutableArray array];
+
+                // Just the array to test the method against
+                // [@(1), @(2), @(2), @(3), @(3), @(3), ...]
+                int N = 10;
+                for (int i = 1; i <= N; i++) {
+                    for (int j = 1; j <= i; j++) {
+                        [originalArray addObject:@(i)];
+                    }
+                }
+
+                NSDictionary *result = [originalArray occurencesOfEachElementInArray];
+
+                for (int i = 1; i <= N; i++) {
+                    [[result[@(i)] should] equal:@(i)];
+                }
+            });
+        });
+
+        describe(@"occurencesOfEachElementInArrayByUsingDictionary", ^{
+            specify(^{
+                NSMutableArray *originalArray = [NSMutableArray array];
+
+                // Just the array to test the method against
+                // [@(1), @(2), @(2), @(3), @(3), @(3), ...]
+                int N = 10;
+                for (int i = 1; i <= N; i++) {
+                    for (int j = 1; j <= i; j++) {
+                        [originalArray addObject:@(i)];
+                    }
+                }
+
+                NSDictionary *result = [originalArray occurencesOfEachElementInArrayByUsingDictionary];
+
+                for (int i = 1; i <= N; i++) {
+                    [[result[@(i)] should] equal:@(i)];
+                }
+            });
+        });
+    });
+
 });
 
 SPEC_END


### PR DESCRIPTION
Howdy!

I've added SpecHelpers.h with `benchmark` method. For example, you may use it to compare how both methods perform:

``` objective-c
// create originalArray (like it is done in specs)
benchmark(100, ^{
    NSDictionary *result = [originalArray occurencesOfEachElementInArrayByUsingDictionary];

    NSLog(@"Result is %@", result);
});

benchmark(100, ^{
    NSDictionary *result = [originalArray occurencesOfEachElementInArray];

    NSLog(@"Result is %@", result);
});
```
