### PR TITLE
Fix for Issue #98 - [NSNumber primeNumbersFromSieveEratosthenesWithMaxNumber:] returns non-prime number (zero)

### DIFF
--- a/EKAlgorithms/NSNumber+EKStuff.m
+++ b/EKAlgorithms/NSNumber+EKStuff.m
@@ -31,6 +31,7 @@
         }
     }
     [resultArray removeObjectIdenticalTo:@0];
+    [resultArray removeObjectIdenticalTo:@((NSInteger)0)];
     
     return [resultArray copy];
 }


### PR DESCRIPTION
Old result:
```
2016-02-21 06:16:09.696 EKAlgorithmsExamples[14912:30304784] Primes from sieve (
    0,
    2,
    3,
    5,
    7,
    11,
    13,
    17,
    19,
    23,
    29,
    31,
    37,
    41
)
```

New result:
```
2016-02-21 06:35:22.611 EKAlgorithmsExamples[89065:27228910] Primes from sieve (
    2,
    3,
    5,
    7,
    11,
    13,
    17,
    19,
    23,
    29,
    31,
    37,
    41
)
```