### PR TITLE
Fix the Kruskals Algorithm example, by not resetting the used flag o…

### DIFF
--- a/EKAlgorithms/Data Structures/Graph/EKGraph.m
+++ b/EKAlgorithms/Data Structures/Graph/EKGraph.m
@@ -185,8 +185,10 @@
     NSAssert([vertices firstObject] != [vertices lastObject], @"Vertices must be different!");
     
     EKQueue *queue = [[EKQueue alloc] init];
-    [self clearVisitHistory];
-    
+    for (EKVertex *vertex in self.vertices) {
+        vertex.wasVisited = NO;
+    }
+
     EKVertex *startVertex  = [vertices firstObject];
     startVertex.wasVisited = YES;
     


### PR DESCRIPTION
Fix the Kruskals Algorithm example, by not resetting the used flag on edges every time a path between vertices is checked.